### PR TITLE
Added a try/catch around ListenerThreadSync

### DIFF
--- a/TouchPortalSDK/Clients/TouchPortalSocket.cs
+++ b/TouchPortalSDK/Clients/TouchPortalSocket.cs
@@ -139,26 +139,33 @@ namespace TouchPortalSDK.Clients
 
             _logger?.LogInformation("Listener thread created and started.");
 
-            while (true)
+            try
             {
-                try
+                while (true)
                 {
-                    var message = _streamReader.ReadLine()
-                                  ?? throw new IOException("Socket closed.");
+                    try
+                    {
+                        var message = _streamReader.ReadLine()
+                                      ?? throw new IOException("Socket closed.");
 
-                    _logger?.LogDebug(message);
+                        _logger?.LogDebug(message);
 
-                    _messageHandler.OnMessage(message);
+                        _messageHandler.OnMessage(message);
+                    }
+                    catch (IOException exception)
+                    {
+                        _messageHandler.Close("Connection Terminated.", exception);
+                        return;
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger?.LogDebug(exception, "Something went wrong on the Listener Thread.");
+                    }
                 }
-                catch (IOException exception)
-                {
-                    _messageHandler.Close("Connection Terminated.", exception);
-                    return;
-                }
-                catch (Exception exception)
-                {
-                    _logger?.LogDebug(exception, "Something went wrong on the Listener Thread.");
-                }
+            }
+            catch (ThreadInterruptedException exception)
+            {
+                _logger?.LogDebug(exception, "The Listener Thread was interrupted.");
             }
         }
     }


### PR DESCRIPTION
Added a try/catch around ListenerThreadSync, to properly capture a ThreadInterruptedException, which is raised when the ITouchPortalClient.Close() is called.

I am using the TouchPortalSDK in an application, separate from TouchPortal. When the application is closed, the TouchPortalClient is closed. This raises an uncaught ThreadInterruptedException. To fix this issue, I have created a try/catch around the ListenerThreadSync method. It will **not** be sufficient to capture the event in the "while(true)" loop, where other exceptions are caught.