### PR TITLE
Add `ICommandHandler::ConnectorUpdateShort()`

### DIFF
--- a/TouchPortalSDK/Clients/TouchPortalClient.cs
+++ b/TouchPortalSDK/Clients/TouchPortalClient.cs
@@ -192,6 +192,20 @@ namespace TouchPortalSDK.Clients
             return SendCommand(command);
         }
 
+        /// <inheritdoc cref="ICommandHandler" />
+        bool ICommandHandler.ConnectorUpdateShort(string shortId, int value)
+        {
+            if (string.IsNullOrWhiteSpace(shortId))
+                return false;
+
+            if (value < 0 || value > 100)
+                return false;
+
+            var command = new ConnectorUpdateShortCommand(_eventHandler.PluginId, shortId, value);
+
+            return SendCommand(command);
+        }
+
         public bool SendCommand<TCommand>(TCommand command, [CallerMemberName]string callerMemberName = "")
             where TCommand : ITouchPortalMessage
         {

--- a/TouchPortalSDK/Interfaces/ICommandHandler.cs
+++ b/TouchPortalSDK/Interfaces/ICommandHandler.cs
@@ -80,6 +80,21 @@ namespace TouchPortalSDK.Interfaces
         /// <returns></returns>
         bool ShowNotification(string notificationId, string title, string message, NotificationOptions[] notificationOptions);
 
+        /// <summary>
+        /// Sends a connector value update to Touch Portal using the long form of the connector ID.
+        /// </summary>
+        /// <param name="connectorId">The long ID of the connector to update. The string "pc_{pluginId}_" is automatically prepended
+        /// before sending to TP. The total length must not exceed 200 chars.</param>
+        /// <param name="value">The value to send, must be between 0 and 100, inclusive.</param>
+        /// <returns>true on success, false otherwise.</returns>
         bool ConnectorUpdate(string connectorId, int value);
+
+        /// <summary>
+        /// Sends a connector value update to Touch Portal using the short form of the connector ID.
+        /// </summary>
+        /// <param name="shortId">The short ID of the connector to update. This is obtained from a <see cref="ShortConnectorIdNotification"/> event.</param>
+        /// <param name="value">The value to send, must be between 0 and 100, inclusive.</param>
+        /// <returns>true on success, false otherwise.</returns>
+        bool ConnectorUpdateShort(string shortId, int value);
     }
 }

--- a/TouchPortalSDK/Messages/Commands/ConnectorUpdateCommand.cs
+++ b/TouchPortalSDK/Messages/Commands/ConnectorUpdateCommand.cs
@@ -1,35 +1,13 @@
-﻿using System;
-using System.Linq;
-using System.Text;
-using TouchPortalSDK.Interfaces;
-using TouchPortalSDK.Messages.Models;
-
+﻿
 namespace TouchPortalSDK.Messages.Commands
 {
-    public class ConnectorUpdateCommand : ITouchPortalMessage
+    public class ConnectorUpdateCommand : ConnectorUpdateCommandBase
     {
-        public string Type => "connectorUpdate";
+        public string ConnectorId { get { return Id; } set { Id = value; } }
 
-        public string ConnectorId { get; set; }
-
-        public int Value { get; set; }
-
-        public ConnectorUpdateCommand(string pluginId, string connectorId, int value)
+        public ConnectorUpdateCommand(string pluginId, string connectorId, int value) : base(pluginId, $"pc_{pluginId}_{connectorId}", value)
         {
-            if (string.IsNullOrWhiteSpace(pluginId))
-                throw new ArgumentNullException(nameof(pluginId));
 
-            if (string.IsNullOrWhiteSpace(connectorId))
-                throw new ArgumentNullException(nameof(connectorId));
-
-            if (value < 0 || value > 100)
-                throw new ArgumentException("Value must be between 0 and 100", nameof(value));
-
-            ConnectorId = $"pc_{pluginId}_{connectorId}";
-            Value = value;
         }
-
-        public Identifier GetIdentifier()
-            => new Identifier(Type, ConnectorId, default);
     }
 }

--- a/TouchPortalSDK/Messages/Commands/ConnectorUpdateCommandBase.cs
+++ b/TouchPortalSDK/Messages/Commands/ConnectorUpdateCommandBase.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using TouchPortalSDK.Interfaces;
+using TouchPortalSDK.Messages.Models;
+
+namespace TouchPortalSDK.Messages.Commands
+{
+    public abstract class ConnectorUpdateCommandBase : ITouchPortalMessage
+    {
+        public string Type => "connectorUpdate";
+
+        public string Id { get; set; }
+
+        public int Value { get; set; }
+
+        public ConnectorUpdateCommandBase(string pluginId, string id, int value)
+        {
+            if (string.IsNullOrWhiteSpace(pluginId))
+                throw new ArgumentNullException(nameof(pluginId));
+
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentNullException(nameof(id));
+
+            if (value < 0 || value > 100)
+                throw new ArgumentException("Value must be between 0 and 100", nameof(value));
+
+            Id = id;
+            Value = value;
+        }
+
+        public Identifier GetIdentifier()
+            => new Identifier(Type, Id, default);
+    }
+}

--- a/TouchPortalSDK/Messages/Commands/ConnectorUpdateShortCommand.cs
+++ b/TouchPortalSDK/Messages/Commands/ConnectorUpdateShortCommand.cs
@@ -1,0 +1,12 @@
+﻿
+namespace TouchPortalSDK.Messages.Commands
+{
+    public class ConnectorUpdateShortCommand : ConnectorUpdateCommandBase
+    {
+        public string ShortId { get { return Id; } set { Id = value; } }
+
+        public ConnectorUpdateShortCommand(string pluginId, string shortId, int value) : base(pluginId, shortId, value) {
+
+        }
+    }
+}


### PR DESCRIPTION
As a way to distinguish using a short ID string vs. the full connector ID. Adds associated distinct class and a common base class for both `ConnectorUpdate*` derivatives.

Since both the short ID and connector ID are strings, and exclusive when sending the update, it seemed simpler to split the functionality up. For one thing there was no elegant way to make distinct constructors (besides swapping value with one of the strings).

Not attached to "Short" in the names, just seemed most concise.

Tested and used with TP 3.0.6 on Windows 10.

Thanks,
-Max