### PR TITLE
Refactor `ActionEvent` and `ConnectorChangeEvent` to use a common base class. 

### DIFF
--- a/TouchPortalSDK/Messages/Events/ActionEvent.cs
+++ b/TouchPortalSDK/Messages/Events/ActionEvent.cs
@@ -1,67 +1,33 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TouchPortalSDK.Interfaces;
-using TouchPortalSDK.Messages.Models;
-using TouchPortalSDK.Messages.Models.Enums;
+﻿using TouchPortalSDK.Messages.Models.Enums;
 
 namespace TouchPortalSDK.Messages.Events
 {
-    public class ActionEvent : ITouchPortalMessage
+    /// <summary>
+    /// <para>
+    ///     Action type event. `Type` attribute can be one of the following:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    ///     <term>action</term>
+    ///     <description>User presses an action button on the device.</description>
+    /// </item>
+    /// <item>
+    ///     <term>down</term>
+    ///     <description>Finger holds down the action on the device. This event happens only if the action enables the hasHoldFunctionality.</description>
+    /// </item>
+    /// <item>
+    ///     <term>up</term>
+    ///     <description>Finger released the action on the device. This event happens only if the action enables the hasHoldFunctionality.</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    /// <inheritdoc cref="DataContainerEventBase" />
+    public class ActionEvent : DataContainerEventBase
     {
-        /// <summary>
-        /// <para>
-        ///     Action type event.
-        /// </para>
-        /// <list type="bullet">
-        /// <item>
-        ///     <term>action</term>
-        ///     <description>User presses an action button on the device.</description>
-        /// </item>
-        /// <item>
-        ///     <term>down</term>
-        ///     <description>Finger holds down the action on the device. This event happens only if the action enables the hasHoldFunctionality.</description>
-        /// </item>
-        /// <item>
-        ///     <term>up</term>
-        ///     <description>Finger released the action on the device. This event happens only if the action enables the hasHoldFunctionality.</description>
-        /// </item>
-        /// </list>
-        /// </summary>
-        public string Type { get; set; }
-
-        /// <summary>
-        /// The id of the plugin.
-        /// </summary>
-        public string PluginId { get; set; }
-
         /// <summary>
         /// The id of the action.
         /// </summary>
-        public string ActionId { get; set; }
-
-        /// <summary>
-        /// Data equals selected values of each dropdown.
-        /// Ex. data1: dropdown1
-        ///     data2: dropdown2
-        /// </summary>
-        public IReadOnlyCollection<ActionDataSelected> Data { get; set; }
-
-        /// <summary>
-        /// Indexer to get data values.
-        /// </summary>
-        /// <param name="dataId">the id of the datafield.</param>
-        /// <returns>the value of the data field as string or null if not exists</returns>
-        public string this[string dataId]
-            => GetValue(dataId);
-
-        /// <summary>
-        /// Returns the value of the selected item in an action data field.
-        /// This value can be null in some cases, and will be null if data field is miss written.
-        /// </summary>
-        /// <param name="dataId">the id of the datafield.</param>
-        /// <returns>the value of the data field as string or null if not exists</returns>
-        public string GetValue(string dataId)
-            => Data?.SingleOrDefault(data => data.Id == dataId)?.Value;
+        public string ActionId { get { return Id; } set { Id = value; } }
 
         /// <summary>
         /// Returns the Action type.
@@ -74,9 +40,5 @@ namespace TouchPortalSDK.Messages.Events
                 "down" => Press.Down,
                 _ => Press.Tap
             };
-
-        /// <inheritdoc cref="ITouchPortalMessage" />
-        public Identifier GetIdentifier()
-            => new Identifier(Type, ActionId, default);
     }
 }

--- a/TouchPortalSDK/Messages/Events/ConnectorChangeEvent.cs
+++ b/TouchPortalSDK/Messages/Events/ConnectorChangeEvent.cs
@@ -1,25 +1,17 @@
-﻿using System.Collections.Generic;
-using TouchPortalSDK.Interfaces;
-using TouchPortalSDK.Messages.Models;
-
+﻿
 namespace TouchPortalSDK.Messages.Events
 {
-    public class ConnectorChangeEvent : ITouchPortalMessage
+    /// <inheritdoc cref="DataContainerEventBase" />
+    public class ConnectorChangeEvent : DataContainerEventBase
     {
         /// <summary>
-        /// Touch Portal closes/stops the plugin or shuts down.
+        /// The connector ID. Alias for DataContainerEventBase::Id.
         /// </summary>
-        public string Type { get; set; }
+        public string ConnectorId { get { return Id; } set { Id = value; } }
 
-        public string PluginId { get; set; }
-
-        public string ConnectorId { get; set; }
-
+        /// <summary>
+        /// Current value of the connector.
+        /// </summary>
         public int Value { get; set; }
-
-        public IReadOnlyCollection<ActionDataSelected> Data { get; set; }
-
-        public Identifier GetIdentifier()
-            => new Identifier(Type, ConnectorId, default);
     }
 }

--- a/TouchPortalSDK/Messages/Events/DataContainerEventBase.cs
+++ b/TouchPortalSDK/Messages/Events/DataContainerEventBase.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TouchPortalSDK.Interfaces;
+using TouchPortalSDK.Messages.Models;
+
+namespace TouchPortalSDK.Messages.Events
+{
+    /// <summary>
+    /// Base class for events which have data members, such as actions and connectors.
+    /// </summary>
+    public abstract class DataContainerEventBase : ITouchPortalMessage
+    {
+        /// <summary>
+        /// The Touch Portal event name.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The id of the plugin.
+        /// </summary>
+        public string PluginId { get; set; }
+
+        /// <summary>
+        /// The id of the action/connector.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Data is name/value pairs of options the user has selected for this action.
+        /// Ex. data1: dropdown1
+        ///     data2: dropdown2
+        /// </summary>
+        public IReadOnlyCollection<ActionDataSelected> Data { get; set; }
+
+        /// <summary>
+        /// Indexer to get data values.
+        /// </summary>
+        /// <param name="dataId">the id of the datafield.</param>
+        /// <returns>the value of the data field as string or null if not exists</returns>
+        public string this[string dataId]
+            => GetValue(dataId);
+
+        /// <summary>
+        /// Returns the value of the selected item in an action data field.
+        /// This value can be null in some cases, and will be null if data field is miss written.
+        /// </summary>
+        /// <param name="dataId">the id of the datafield.</param>
+        /// <returns>the value of the data field as string or null if not exists</returns>
+        public string GetValue(string dataId)
+                => Data?.SingleOrDefault(data => data.Id == dataId)?.Value;
+
+        public Identifier GetIdentifier()
+            => new Identifier(Type, Id, default);
+    }
+}


### PR DESCRIPTION
This one is more of a "feature request" I suppose vs. an actual need.  I can explain the use case, besides just code reuse.

Connectors and Actions are very similar, and especially that both contain Data structures which often need to be processed, often for the same kind of data.

While working on a plugin just now with a bunch of similar processing for actions and connectors I found that a lot of code could be reused for processing the data [1].  At the same time all the info attached to the actual event are also still useful (like the ID, and the `GetValue()` method), vs. just passing around the Data list.  So, at least in some cases it was nice to have a common base class to pass around.

This seemed like a decent way to do it, but of course I could do it some other way like implementing my own wrapper/abstraction around the two classes in my plugin (or an extension).

I also have a version with a new `ITouchPortalDataMessage` interface layer (inheriting from `ITouchPortalMessage`), from which the base `DataContainerEventBase` could inherit.  I'm not sure it needs that interface layer, so I left it out, but it would be easy to pop that back in.

Tested with TP 3.0.6, Windows 10.

Thanks, 
-Max

[1]  A vJoy interface where much of the same stuff can be controlled via buttons/actions or sliders, the main difference being where the "value" comes from, a slider 0-100 or something the user entered directly.