### PR TITLE
Add `IsConnected` property to TouchPortalClient and TouchPortalSocket.

### DIFF
--- a/TouchPortalSDK/Clients/TouchPortalClient.cs
+++ b/TouchPortalSDK/Clients/TouchPortalClient.cs
@@ -16,6 +16,9 @@ namespace TouchPortalSDK.Clients
     [SuppressMessage("Critical Code Smell", "S1006:Method overrides should not change parameter defaults", Justification = "Service resolved from IoC framework.")]
     public class TouchPortalClient : ITouchPortalClient, IMessageHandler
     {
+        /// <inheritdoc cref="ITouchPortalClient" />
+        public bool IsConnected { get => _touchPortalSocket?.IsConnected ?? false; }
+
         private readonly ILogger<TouchPortalClient> _logger;
         private readonly ITouchPortalEventHandler _eventHandler;
         private readonly ITouchPortalSocket _touchPortalSocket;

--- a/TouchPortalSDK/Clients/TouchPortalSocket.cs
+++ b/TouchPortalSDK/Clients/TouchPortalSocket.cs
@@ -11,6 +11,8 @@ namespace TouchPortalSDK.Clients
 {
     public class TouchPortalSocket : ITouchPortalSocket
     {
+        public bool IsConnected { get => _socket?.Connected ?? false; }
+
         private readonly TouchPortalOptions _options;
         private readonly IMessageHandler _messageHandler;
         private readonly ILogger<TouchPortalSocket> _logger;
@@ -19,7 +21,7 @@ namespace TouchPortalSDK.Clients
 
         private StreamWriter _streamWriter;
         private StreamReader _streamReader;
-        
+
         public TouchPortalSocket(TouchPortalOptions options,
                                  IMessageHandler messageHandler,
                                  ILoggerFactory loggerFactory = null)

--- a/TouchPortalSDK/Interfaces/ITouchPortalClient.cs
+++ b/TouchPortalSDK/Interfaces/ITouchPortalClient.cs
@@ -3,6 +3,11 @@
     public interface ITouchPortalClient : ICommandHandler
     {
         /// <summary>
+        /// The connection state of this client. `true` when an active socket to Touch Portal is open.
+        /// </summary>
+        public bool IsConnected { get; }
+
+        /// <summary>
         /// Connects, pairs, and listens to the Touch Portal application.
         /// </summary>
         /// <returns>connection success status</returns>

--- a/TouchPortalSDK/Interfaces/ITouchPortalSocket.cs
+++ b/TouchPortalSDK/Interfaces/ITouchPortalSocket.cs
@@ -3,6 +3,11 @@
     public interface ITouchPortalSocket
     {
         /// <summary>
+        /// The connection state of the Socket being used internally.
+        /// </summary>
+        public bool IsConnected { get; }
+
+        /// <summary>
         /// Connects to Touch Portal.
         /// </summary>
         /// <returns>success flag</returns>


### PR DESCRIPTION
It may seem redundant if one is relying on the communication thread to keep one's plugin alive, but in other situations it can be quite handy.  I vacillated between `Connected` and `IsConnected` and am fine with either. The "Is" just seems more specific, but OTOH `Socket` uses `Connected` so it was a tough choice... :)